### PR TITLE
README install instructions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ AWS firewalls prevent any of these from being accessed from outside the network.
 
 ## Installation
 
+Install [docker](https://docs.docker.com/install/):
+
+1. 'sudo apt-get remove docker docker-engine docker.io containerd runc'
+2. 'sudo apt-get update'
+3. 'sudo apt-get install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common'
+4. 'curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -'
+5. 'sudo apt-key fingerprint 0EBFCD88'
+6. 'sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"'
+7. 'sudo apt-get update'
+8. 'sudo apt-get install docker-ce docker-ce-cli containerd.io'
+
+
+
 Install [docker-compose](https://linuxize.com/post/how-to-install-and-use-docker-compose-on-ubuntu-18-04/):
 
 1. `sudo curl -L "https://github.com/docker/compose/releases/download/1.23.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose`
@@ -30,3 +51,4 @@ Install this package:
 1. `git clone https://github.com/laws-africa/elk-docker.git`
 2. `cd elk-docker`
 5. `docker-compose up -d`
+Note that you will likely need to run docker-compose as sudo


### PR DESCRIPTION
updated README to include docker installation instructions and a note regarding running docker-compose without sudo (since the docker-compose error message does not obviously indicate a permissions issue)